### PR TITLE
[10.0] [MIG] [FIX] connector_prestashop: Fixes in v10.0 migration

### DIFF
--- a/connector_prestashop/models/account_payment_mode/common.py
+++ b/connector_prestashop/models/account_payment_mode/common.py
@@ -34,11 +34,13 @@ class PaymentModeBinder(Component):
     def to_internal(self, external_id, unwrap=False, company=None):
         if company is None:
             company = self.backend_record.company_id
-        bindings = self.model.with_context(active_test=False).search(
-            [(self._external_field, '=', external_id),
-             ('company_id', '=', company.id),
-             ]
-        )
+        bindings = self.model
+        for language in self.backend_record.language_ids:
+            bindings |= self.model.with_context(
+                active_test=False,
+                lang=language.code).search([
+                    (self._external_field, '=', external_id),
+                    ('company_id', '=', company.id)])
         if not bindings:
             return self.model.browse()
         bindings.ensure_one()

--- a/connector_prestashop/models/product_product/common.py
+++ b/connector_prestashop/models/product_product/common.py
@@ -30,7 +30,8 @@ class ProductProduct(models.Model):
         for product in self:
             if product.product_variant_count > 1:
                 # Recompute qty in combination binding
-                for combination_binding in product.prestashop_bind_ids:
+                for combination_binding in \
+                        product.prestashop_combinations_bind_ids:
                     combination_binding.recompute_prestashop_qty()
             # Recompute qty in product template binding if any combination
             # if modified

--- a/connector_prestashop/models/product_supplierinfo/importer.py
+++ b/connector_prestashop/models/product_supplierinfo/importer.py
@@ -95,6 +95,7 @@ class SupplierInfoMapper(Component):
 
     direct = [
         ('product_supplier_reference', 'product_code'),
+        ('product_supplier_price_te', 'price'),
     ]
 
     @mapping
@@ -127,6 +128,12 @@ class SupplierInfoMapper(Component):
         binder = self.binder_for('prestashop.product.template')
         template = binder.to_internal(record['id_product'], unwrap=True)
         return {'product_tmpl_id': template.id}
+
+    @mapping
+    def currency_id(self, record):
+        binder = self.binder_for('prestashop.res.currency')
+        currency = binder.to_internal(record['id_currency'], unwrap=True)
+        return {'currency_id': currency.id}
 
     @mapping
     def required(self, record):

--- a/connector_prestashop/models/product_template/importer.py
+++ b/connector_prestashop/models/product_template/importer.py
@@ -597,7 +597,7 @@ class ProductTemplateImporter(Component):
                 self._import_combination(combination)
 
             if combinations and associations['images'].get('image'):
-                self._delay_product_image_variant(combinations)
+                self._delay_product_image_variant([first_exec] + combinations)
 
     def import_images(self, binding):
         prestashop_record = self._get_prestashop_data()

--- a/connector_prestashop/models/product_template/importer.py
+++ b/connector_prestashop/models/product_template/importer.py
@@ -383,6 +383,15 @@ class ProductInventoryBatchImporter(Component):
     def _run_page(self, filters, **kwargs):
         records = self.backend_adapter.get(filters)
         for record in records['stock_availables']['stock_available']:
+            # if product has combinations then do not import product stock
+            # since combination stocks will be imported
+            if record['id_product_attribute'] == '0':
+                combination_stock_ids = self.backend_adapter.search({
+                    'filter[id_product]': record['id_product'],
+                    'filter[id_product_attribute]': '>[0]',
+                })
+                if combination_stock_ids:
+                    continue
             self._import_record(record['id'], record=record, **kwargs)
         return records['stock_availables']['stock_available']
 

--- a/connector_prestashop/models/sale_order/importer.py
+++ b/connector_prestashop/models/sale_order/importer.py
@@ -453,9 +453,7 @@ class SaleOrderLineMapper(Component):
         result = self.env['account.tax'].browse()
         for ps_tax in taxes:
             result |= self._find_tax(ps_tax['id'])
-        if result:
-            return {'tax_id': [(6, 0, result.ids)]}
-        return {}
+        return {'tax_id': [(6, 0, result.ids)]}
 
     @mapping
     def backend_id(self, record):


### PR DESCRIPTION
Hello,

In this PR I will fix issues reported by myself in Tecnativa/connector-prestashop#6:

### From Backend
- Import product categories and products
  - [x] Associate images to the correct variants - OCA/product-attribute#359 and 1a46ab9
- Import payment modes
  - [x] Do not duplicate payment modes for each language - a872e80 Payment modes are binded by name therefore must be translated
- Import sale orders
  - [x] Do not set default product taxes if they are unset in Prestashop - 421cd04
- Import suppliers
  - [x] Import supplier prices - 79d322b
- Import stock quantities
  - [x] Stock quantities imported are incorrect if product has variants - 2d9ffd5
- Export stock quantities 
  - [x] ~~Fails for variants with "PrestaShopWebServiceError: 'This filter does not exist. Did you mean: "id_shop"? ...'"- 1280031~~

### On stock change
- [x] Combination quantity is not exported when variant stock changes - b78a27f

Thanks!