### PR TITLE
Improve partner import performance

### DIFF
--- a/connector_prestashop/models/res_partner/importer.py
+++ b/connector_prestashop/models/res_partner/importer.py
@@ -70,10 +70,6 @@ class PartnerImportMapper(Component):
         return result
 
     @mapping
-    def backend_id(self, record):
-        return {'backend_id': self.backend_record.id}
-
-    @mapping
     def lang(self, record):
         binder = self.binder_for('prestashop.res.lang')
         erp_lang = None


### PR DESCRIPTION
Ce mapping est inutile puisque le backend_id est un champs related sur shop_group_id, lui même obligatoire.

Le fait de faire un write sur ce champs related entraîne, d'une façon ou d'une autre (je ne suis pas rentré dans les détails un write ensuite sur tous les clients de la BDD (ayant le même backend).
J'ai testé cela sur un client en v8, le job passe de 50 secondes à moins d'une seconde...

@bguillot 